### PR TITLE
While requesting quote, city should not be case sensitive.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 
 var codesUS = require('./codes'),
     states = require('./states'),
-    codesCanada = require('./codesCanada');
+    codesCanada = require('./codesCanada'),
+    ucfirst = require('../scripts/process');
 
 var codes = {}
 codes.codes = Object.assign({}, codesUS.codes, codesCanada.codes);
@@ -30,6 +31,7 @@ var lookup = function(zip, city=null) {
     }
     else
     {
+        city = ucfirst(city.toLowerCase());
         if(zipCodeObject.city.indexOf(city) != -1)
         {
             cities = [city, ...(zipCodeObject.city.filter((c) => { return c !== city; }))];

--- a/scripts/process.js
+++ b/scripts/process.js
@@ -59,3 +59,4 @@ str = 'exports.codes = ' + JSON.stringify(zips,null,2) + ';\n';
 str += 'exports.stateMap = ' + JSON.stringify(stateMap,null,2) + ';\n';
 
 fs.writeFileSync(path.join('../', 'lib', 'codes.js'), str, 'utf8');
+exports.ucfirst = ucfirst;

--- a/tests/lookup.js
+++ b/tests/lookup.js
@@ -42,6 +42,22 @@ var tests = {
             assert.equal(carson.city[0], 'Carson');
         }
     },
+    'CarsonLowerCase': {
+        topic: function() {
+            return zipcodes.lookup(90810, 'carson');
+        },
+        'should be ok': function(carson) {
+            assert.equal(carson.city[0], 'Carson');
+        }
+    },
+    'CarsonUpperCase': {
+        topic: function() {
+            return zipcodes.lookup(90810, 'CARSON');
+        },
+        'should be ok': function(carson) {
+            assert.equal(carson.city[0], 'Carson');
+        }
+    },
     'Kananaskis': {
       topic: function() {
         return zipcodes.lookup("T0L");


### PR DESCRIPTION
While requesting quote, city should not be case sensitive. We should be able to handle the origin and destination cities regardless of the case.
